### PR TITLE
Fix 301 redirection error in fetching data from ecb.europa.eu

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Test Coverage](https://api.codeclimate.com/v1/badges/c67969dd7b921477bdcc/test_coverage)](https://codeclimate.com/github/matthutchinson/ecb_exchange/test_coverage)
 
 Currency conversion using the European Central Bank's foreign [exchange
-rates](http://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml). Rates
+rates](https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml). Rates
 for the last 90 days are fetched and cached on demand. All calculations are
   performed and returned as `BigDecimal` (usually a [good
   idea](https://makandracards.com/makandra/1178-bigdecimal-arithmetic-in-ruby)
@@ -67,7 +67,7 @@ ECB::Exchange::XMLFeed.endpoint = "http://my-awesome-service.com/feed.xml"
 ```
 
 The XML feed at this endpoint must conform to the [ECB
-rates](http://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml)
+rates](https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml)
 structure.
 
 ## Handling Errors

--- a/lib/ecb/exchange/xml_feed.rb
+++ b/lib/ecb/exchange/xml_feed.rb
@@ -8,7 +8,7 @@ module ECB
   module Exchange
     class XMLFeed
 
-      NINETY_DAY_ENDPOINT = "http://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml".freeze
+      NINETY_DAY_ENDPOINT = "https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml".freeze
       @endpoint = URI(NINETY_DAY_ENDPOINT)
 
       # allow a configurable endpoint
@@ -44,7 +44,9 @@ module ECB
         end
 
         def self.get_xml
-          resp = Net::HTTP.new(endpoint.host, endpoint.port).get(endpoint.path)
+          http = Net::HTTP.new(endpoint.host, endpoint.port)
+          http.use_ssl = endpoint.scheme === "https"
+          resp = http.get(endpoint.path)
           if resp.code == "200"
             resp.body
           else


### PR DESCRIPTION
__What this PR does / why we need it:__

To fix 301 redirection error in fetching data from the endpoint, I change the endpoint from http://~ to https://~.

```
> ECB::Exchange.currencies
ECB::Exchange::ResponseError: fetching 'http://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml' failed - status: 301
```

```
$ curl http://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml
<html>
<head><title>301 Moved Permanently</title></head>
<body bgcolor="white">
<center><h1>301 Moved Permanently</h1></center>
<hr><center>Myra</center>
</body>
</html>
```

---
#### :memo: Checklist

Please check this list and leave it intact for the reviewer. Thanks! :heart:

- [x] Commit messages provide context (why not just what, some tips [here](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)).
- [x] ~If relevant, mention GitHub issue number above and include in a commit message.~
- [x] Latest code from master merged.
- [x] New behaviour has test coverage.
- [x] Avoid duplicating code.
- [x] No commented out code.
- [x] Avoid comments for your code, write code that explains itself.
- [x] Changes are simple, useful, clear and brief.
